### PR TITLE
feat: Implement state and actions to manage ERD data

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "ignorePatterns": [
-    "src/__test__/*",
+    "src/__tests__",
     ".next",
     "jest.config.ts",
     "babel.config.js"
@@ -14,14 +14,24 @@
     "plugin:@typescript-eslint/recommended",
     "prettier"
   ],
-  "plugins": ["@typescript-eslint", "react", "@tanstack/query"],
+  "plugins": [
+    "@typescript-eslint",
+    "react",
+    "@tanstack/query"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json"
   },
   "rules": {
-    "semi": ["error", "always"],
-    "max-depth": ["error", 3],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "max-depth": [
+      "error",
+      3
+    ],
     "import/prefer-default-export": "off",
     "import/no-default-export": "error",
     "@typescript-eslint/no-floating-promises": "off",
@@ -43,7 +53,15 @@
     "import/order": [
       "error",
       {
-        "groups": ["builtin", "external", ["parent", "sibling"], "index"],
+        "groups": [
+          "builtin",
+          "external",
+          [
+            "parent",
+            "sibling"
+          ],
+          "index"
+        ],
         "pathGroups": [
           {
             "pattern": "react",
@@ -71,7 +89,9 @@
     "react/jsx-filename-extension": [
       "error",
       {
-        "extensions": [".tsx"]
+        "extensions": [
+          ".tsx"
+        ]
       }
     ],
     "no-use-before-define": "off",
@@ -80,25 +100,34 @@
   },
   "overrides": [
     {
-      "files": ["src/**/*.tsx"],
+      "files": [
+        "src/**/*.tsx",
+        "src/features/**/*"
+      ],
       "rules": {
         "max-lines-per-function": "off"
       }
     },
     {
-      "files": ["src/app/**/*.tsx"],
+      "files": [
+        "src/app/**/*.tsx"
+      ],
       "rules": {
         "import/no-default-export": "off"
       }
     },
     {
-      "files": ["src/app/layout.tsx"],
+      "files": [
+        "src/app/layout.tsx"
+      ],
       "rules": {
         "react/jsx-max-depth": "off"
       }
     },
     {
-      "files": ["src/__tests__/**/*"],
+      "files": [
+        "src/__tests__/**/*"
+      ],
       "env": {
         "jest": true
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -96,7 +96,13 @@
     ],
     "no-use-before-define": "off",
     "@typescript-eslint/no-use-before-define": "off",
-    "@next/next/no-img-element": "off"
+    "@next/next/no-img-element": "off",
+    "no-param-reassign": [
+      "error",
+      {
+        "props": false
+      }
+    ]
   },
   "overrides": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
         "@tanstack/react-query-devtools": "^5.56.2",
         "axios": "^1.7.7",
         "classnames": "^2.5.1",
+        "immer": "^10.1.1",
         "next": "14.2.7",
         "react": "^18",
         "react-dom": "^18",
         "rxjs": "^7.8.1",
+        "uuid": "^10.0.0",
         "zustand": "^4.5.5"
       },
       "devDependencies": {
@@ -30,6 +32,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.57.0",
@@ -2204,6 +2207,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5703,6 +5713,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -9928,6 +9948,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "@tanstack/react-query-devtools": "^5.56.2",
     "axios": "^1.7.7",
     "classnames": "^2.5.1",
+    "immer": "^10.1.1",
     "next": "14.2.7",
     "react": "^18",
     "react-dom": "^18",
     "rxjs": "^7.8.1",
+    "uuid": "^10.0.0",
     "zustand": "^4.5.5"
   },
   "devDependencies": {
@@ -32,6 +34,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "eslint": "^8.57.0",

--- a/src/__tests__/erd-project.slice.test.ts
+++ b/src/__tests__/erd-project.slice.test.ts
@@ -102,6 +102,29 @@ describe('ERD Project Store', () => {
 
       expect(store.getState().tables.length).toBe(0);
     });
+
+    test('테이블을 삭제하는 것은, 다른 테이블에 영향을 미칠 수 있습니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createRelation(relation);
+
+      const beforeTable2 = store
+        .getState()
+        .tables.find((table) => table.id === relation.to);
+
+      expect(beforeTable2?.columns.length).toBe(1);
+
+      store.getState().deleteTable(table1.id);
+
+      const afterTable2 = store
+        .getState()
+        .tables.find((table) => table.id === relation.to);
+
+      expect(store.getState().tables.length).toBe(1);
+      expect(afterTable2?.columns.length).toBe(0);
+    });
   });
 
   describe('컬럼 관련 액션', () => {

--- a/src/__tests__/erd-project.slice.test.ts
+++ b/src/__tests__/erd-project.slice.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+  createERDProjectStore,
+  ERDRelation,
+  type ERDTable,
+} from '@/features/erd-project';
+
+describe('사용자의 프로젝트 관련 데이터 테스트', () => {
+  const table1: ERDTable = {
+    id: 'table1',
+    top: 0,
+    left: 0,
+    width: 100,
+    height: 100,
+  };
+  const table2: ERDTable = {
+    id: 'table2',
+    top: 0,
+    left: 0,
+    width: 100,
+    height: 100,
+  };
+  const relation: ERDRelation = {
+    id: 'relation1',
+    type: 'one-to-one',
+    from: table1.id,
+    to: table2.id,
+    identify: false,
+  };
+
+  describe('Project 관련', () => {
+    test('Project 설명이 정상적으로 변경되어야 합니다.', () => {
+      const store = createERDProjectStore();
+
+      store
+        .getState()
+        .updateDescriptions({ title: 'title', description: 'description' });
+
+      expect(store.getState().title).toBe('title');
+      expect(store.getState().description).toBe('description');
+    });
+
+    test('Project의 캔버스 크기가 변경되어야 합니다.', () => {
+      const store = createERDProjectStore();
+
+      store.getState().updateCanvasSize({ width: 100, height: 100 });
+
+      expect(store.getState().width).toBe(100);
+      expect(store.getState().height).toBe(100);
+    });
+
+    test('Project의 캔버스 크기가 0 또는 음수인 경우 오류를 반환합니다.', () => {
+      const store = createERDProjectStore();
+
+      expect(() =>
+        store.getState().updateCanvasSize({ width: -1, height: -1 }),
+      ).toThrowError(new Error('width, height must greater than 0'));
+    });
+  });
+
+  describe('ERD Table 관련', () => {
+    test('Table 추가가 정상적으로 이루어져야 합니다.', () => {
+      const store = createERDProjectStore();
+
+      store.getState().createTable(table1);
+
+      expect(store.getState().tables.length).toBe(1);
+    });
+
+    test('Table 업데이트가 정상적으로 이루어져야 합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+
+      store.getState().updateTable({ ...table1, top: 100, height: 100 });
+
+      const table = store.getState().tables.find((t) => t.id === table1.id);
+      expect(table).not.toBeUndefined();
+      expect(table?.top).toBe(100);
+      expect(table?.height).toBe(100);
+    });
+
+    test('Table 삭제가 정상적으로 이루어져야 합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+
+      store.getState().deleteTable(table1.id);
+
+      expect(store.getState().tables.length).toBe(0);
+    });
+  });
+
+  describe('ERD Relation 관련', () => {
+    test('Relation 생성이 정상적으로 이루어져야 합니다.', () => {
+      const store = createERDProjectStore();
+
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createRelation(relation);
+
+      expect(store.getState().relations[table1.id]).not.toBeUndefined();
+      expect(store.getState().relations[table2.id]).not.toBeUndefined();
+    });
+
+    test('Relation 수정이 정상적으로 이루어져야 합니다.', () => {
+      const store = createERDProjectStore();
+
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createRelation(relation);
+      store.getState().updateRelation({ ...relation, identify: true });
+
+      const target = store
+        .getState()
+        .relations[table1.id].find((v) => v.id === relation.id);
+
+      expect(target).not.toBeUndefined();
+      expect(target?.identify).toBe(true);
+    });
+
+    test('Relation 삭제가 정상적으로 이루어져야 합니다.', () => {
+      const store = createERDProjectStore();
+
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createRelation(relation);
+      store.getState().deleteRelation(relation);
+
+      expect(store.getState().relations[table1.id]).not.toBeUndefined();
+      expect(store.getState().relations[table2.id]).not.toBeUndefined();
+      expect(store.getState().relations[table1.id].length).toBe(0);
+      expect(store.getState().relations[table2.id].length).toBe(0);
+    });
+  });
+});

--- a/src/__tests__/erd-project.slice.test.ts
+++ b/src/__tests__/erd-project.slice.test.ts
@@ -1,135 +1,459 @@
 import { describe, expect, test } from '@jest/globals';
-
 import {
   createERDProjectStore,
+  ERDProject,
   ERDRelation,
-  type ERDTable,
+  ERDTable,
 } from '@/features/erd-project';
 
-describe('사용자의 프로젝트 관련 데이터 테스트', () => {
+describe('ERD Project Store', () => {
   const table1: ERDTable = {
     id: 'table1',
+    title: 'Table 1',
     top: 0,
     left: 0,
     width: 100,
     height: 100,
+    columns: [],
   };
+
   const table2: ERDTable = {
     id: 'table2',
+    title: 'Table 2',
     top: 0,
     left: 0,
     width: 100,
     height: 100,
+    columns: [],
   };
+
   const relation: ERDRelation = {
     id: 'relation1',
+    from: 'table1',
+    to: 'table2',
     type: 'one-to-one',
-    from: table1.id,
-    to: table2.id,
-    identify: false,
+    identify: true,
   };
 
-  describe('Project 관련', () => {
-    test('Project 설명이 정상적으로 변경되어야 합니다.', () => {
+  describe('프로젝트 관련 액션', () => {
+    test('프로젝트를 설정합니다.', () => {
       const store = createERDProjectStore();
+      const newProject: ERDProject = {
+        id: 'newProject',
+        title: 'New Project',
+        width: 500,
+        height: 500,
+        tables: [],
+        relations: {},
+      };
 
-      store
-        .getState()
-        .updateDescriptions({ title: 'title', description: 'description' });
-
-      expect(store.getState().title).toBe('title');
-      expect(store.getState().description).toBe('description');
+      store.getState().setProject(newProject);
+      expect(store.getState().id).toBe('newProject');
+      expect(store.getState().title).toBe('New Project');
     });
 
-    test('Project의 캔버스 크기가 변경되어야 합니다.', () => {
+    test('프로젝트 설명을 업데이트합니다.', () => {
       const store = createERDProjectStore();
+      store.getState().updateDescriptions({
+        title: 'Updated Title',
+        description: 'Updated Description',
+      });
 
-      store.getState().updateCanvasSize({ width: 100, height: 100 });
-
-      expect(store.getState().width).toBe(100);
-      expect(store.getState().height).toBe(100);
+      expect(store.getState().title).toBe('Updated Title');
+      expect(store.getState().description).toBe('Updated Description');
     });
 
-    test('Project의 캔버스 크기가 0 또는 음수인 경우 오류를 반환합니다.', () => {
+    test('캔버스 크기를 업데이트합니다.', () => {
       const store = createERDProjectStore();
+      store.getState().updateCanvasSize({ width: 800, height: 600 });
+
+      expect(store.getState().width).toBe(800);
+      expect(store.getState().height).toBe(600);
 
       expect(() =>
-        store.getState().updateCanvasSize({ width: -1, height: -1 }),
-      ).toThrowError(new Error('width, height must greater than 0'));
+        store.getState().updateCanvasSize({ width: -100, height: 600 }),
+      ).toThrow();
     });
   });
 
-  describe('ERD Table 관련', () => {
-    test('Table 추가가 정상적으로 이루어져야 합니다.', () => {
+  describe('테이블 관련 액션', () => {
+    test('테이블을 생성합니다.', () => {
       const store = createERDProjectStore();
-
       store.getState().createTable(table1);
 
       expect(store.getState().tables.length).toBe(1);
+      expect(store.getState().tables[0].title).toBe('Table 1');
     });
 
-    test('Table 업데이트가 정상적으로 이루어져야 합니다.', () => {
+    test('테이블을 업데이트합니다.', () => {
       const store = createERDProjectStore();
       store.getState().createTable(table1);
 
-      store.getState().updateTable({ ...table1, top: 100, height: 100 });
+      const updatedTable = { ...table1, title: 'Updated Table 1' };
+      store.getState().updateTable(updatedTable);
 
-      const table = store.getState().tables.find((t) => t.id === table1.id);
-      expect(table).not.toBeUndefined();
-      expect(table?.top).toBe(100);
-      expect(table?.height).toBe(100);
+      expect(store.getState().tables[0].title).toBe('Updated Table 1');
     });
 
-    test('Table 삭제가 정상적으로 이루어져야 합니다.', () => {
+    test('테이블을 삭제합니다.', () => {
       const store = createERDProjectStore();
       store.getState().createTable(table1);
-
       store.getState().deleteTable(table1.id);
 
       expect(store.getState().tables.length).toBe(0);
     });
   });
 
-  describe('ERD Relation 관련', () => {
-    test('Relation 생성이 정상적으로 이루어져야 합니다.', () => {
+  describe('컬럼 관련 액션', () => {
+    test('컬럼을 생성합니다.', () => {
       const store = createERDProjectStore();
-
       store.getState().createTable(table1);
-      store.getState().createTable(table2);
-      store.getState().createRelation(relation);
+      store.getState().createColumn(table1, true);
 
-      expect(store.getState().relations[table1.id]).not.toBeUndefined();
-      expect(store.getState().relations[table2.id]).not.toBeUndefined();
+      const table = store
+        .getState()
+        .tables.find((table) => table.title === 'Table 1');
+
+      expect(table).not.toBeUndefined();
+      expect(table?.columns.length).toBe(1);
     });
 
-    test('Relation 수정이 정상적으로 이루어져야 합니다.', () => {
+    test('PK인 컬럼이 추가되면, 릴레이션에 따라 영향을 미칩니다.', () => {
       const store = createERDProjectStore();
-
       store.getState().createTable(table1);
       store.getState().createTable(table2);
       store.getState().createRelation(relation);
+
+      expect(
+        store.getState().tables.find((t) => t.id === table1.id)?.columns.length,
+      ).toBe(0);
+      expect(
+        store.getState().tables.find((t) => t.id === table2.id)?.columns.length,
+      ).toBe(0);
+
+      store.getState().createColumn(table1, true);
+
+      expect(
+        store.getState().tables.find((t) => t.id === table1.id)?.columns.length,
+      ).toBe(1);
+      expect(
+        store.getState().tables.find((t) => t.id === table2.id)?.columns.length,
+      ).toBe(1);
+    });
+
+    test('PK가 아닌 컬럼이 추가되면, 릴레이션과 상관 없이 영향을 미쳐선 안 됩니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createRelation(relation);
+
+      expect(
+        store.getState().tables.find((t) => t.id === table1.id)?.columns.length,
+      ).toBe(0);
+      expect(
+        store.getState().tables.find((t) => t.id === table2.id)?.columns.length,
+      ).toBe(0);
+
+      store.getState().createColumn(table1, false);
+
+      expect(
+        store.getState().tables.find((t) => t.id === table1.id)?.columns.length,
+      ).toBe(1);
+      expect(
+        store.getState().tables.find((t) => t.id === table2.id)?.columns.length,
+      ).toBe(0);
+    });
+
+    test('컬럼을 업데이트합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createColumn(table1, true);
+
+      const table = store
+        .getState()
+        .tables.find((table) => table.title === 'Table 1');
+      const column = table?.columns[0];
+      if (column) {
+        const updatedColumn = { ...column, name: 'Updated Column' };
+        store.getState().updateColumn(table1, updatedColumn);
+
+        const updatedTable = store
+          .getState()
+          .tables.find((table) => table.title === 'Table 1');
+        const updatedCol = updatedTable?.columns.find(
+          (col) => col.id === column.id,
+        );
+        expect(updatedCol?.name).toBe('Updated Column');
+      }
+    });
+
+    test('테이블1의 컬럼이 업데이트되면 테이블2에 영향을 미칩니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createRelation(relation);
+
+      const table = store.getState().tables.find((t) => t.id === 'table1');
+      expect(table).not.toBeUndefined();
+
+      const column = table?.columns[0];
+      expect(column).not.toBeUndefined();
+
+      store.getState().updateColumn(table!, { ...column!, name: 'test-name' });
+
+      const updatedTable1 = store
+        .getState()
+        .tables.find((t) => t.id === 'table1');
+      const updatedTable2 = store
+        .getState()
+        .tables.find((t) => t.id === 'table2');
+
+      const updatedColumn1 = updatedTable1?.columns.find(
+        (c) => c.name === 'test-name',
+      );
+      const updatedColumn2 = updatedTable2?.columns.find(
+        (c) => c.name === 'test-name',
+      );
+
+      expect(updatedColumn1).not.toBeUndefined();
+      expect(updatedColumn2).not.toBeUndefined();
+      expect(updatedColumn1!.name).toBe('test-name');
+      expect(updatedColumn2!.name).toBe('test-name');
+    });
+
+    test('컬럼을 삭제합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createColumn(table1, true);
+
+      const table = store
+        .getState()
+        .tables.find((table) => table.title === 'Table 1');
+      const column = table?.columns[0];
+      if (column) {
+        store.getState().deleteColumn(table1, column);
+
+        const updatedTable = store
+          .getState()
+          .tables.find((table) => table.title === 'Table 1');
+        expect(updatedTable?.columns.length).toBe(0);
+      }
+    });
+
+    test('컬럼을 삭제하면, PK인 경우 릴레이션에 따라 영향을 미칩니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createRelation(relation);
+      store.getState().createColumn(table1, true);
+
+      const table1Before = store
+        .getState()
+        .tables.find((t) => t.id === 'table1');
+      const table2Before = store
+        .getState()
+        .tables.find((t) => t.id === 'table2');
+      expect(table1Before?.columns.length).toBe(1);
+      expect(table2Before?.columns.length).toBe(1);
+
+      const table = store
+        .getState()
+        .tables.find((table) => table.title === 'Table 1');
+      const column = table?.columns[0];
+      if (column) {
+        store.getState().deleteColumn(table1, column);
+
+        const updatedTable1 = store
+          .getState()
+          .tables.find((t) => t.id === 'table1');
+        const updatedTable2 = store
+          .getState()
+          .tables.find((t) => t.id === 'table2');
+
+        expect(updatedTable1?.columns.length).toBe(0);
+        expect(updatedTable2?.columns.length).toBe(0);
+      }
+    });
+
+    test('컬럼을 삭제하면, PK가 아닌 경우 릴레이션과 상관 없이 영향을 미쳐선 안 됩니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createRelation(relation);
+      store.getState().createColumn(table1, false);
+
+      const table1Before = store
+        .getState()
+        .tables.find((t) => t.id === 'table1');
+      const table2Before = store
+        .getState()
+        .tables.find((t) => t.id === 'table2');
+      expect(table1Before?.columns.length).toBe(1);
+      expect(table2Before?.columns.length).toBe(0);
+
+      const table = store
+        .getState()
+        .tables.find((table) => table.title === 'Table 1');
+      const column = table?.columns[0];
+      if (column) {
+        store.getState().deleteColumn(table1, column);
+
+        const updatedTable1 = store
+          .getState()
+          .tables.find((t) => t.id === 'table1');
+        const updatedTable2 = store
+          .getState()
+          .tables.find((t) => t.id === 'table2');
+
+        expect(updatedTable1?.columns.length).toBe(0);
+        expect(updatedTable2?.columns.length).toBe(0);
+      }
+    });
+  });
+
+  describe('릴레이션 관련 액션', () => {
+    test('릴레이션을 생성합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createRelation(relation);
+
+      expect(store.getState().relations[table1.id].length).toBe(1);
+      expect(store.getState().relations[table2.id].length).toBe(1);
+    });
+
+    test('릴레이션이 생성되면 다른 테이블의 컬럼에 영향을 미칩니다. 이 경우엔 식별 관계입니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createColumn(table2, true);
+      store.getState().createRelation(relation);
+
+      const table = store
+        .getState()
+        .tables.find((table) => table.title === 'Table 2');
+
+      expect(table).not.toBeUndefined();
+      expect(table?.columns.length).toBe(2);
+    });
+
+    test('릴레이션이 생성되면 다른 테이블의 컬럼에 영향을 미칩니다. 이 경우엔 비식별 관계입니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createColumn(table2, true);
+      store.getState().createRelation({
+        ...relation,
+        identify: false,
+      });
+
+      const table = store
+        .getState()
+        .tables.find((table) => table.title === 'Table 2');
+
+      expect(table).not.toBeUndefined();
+      expect(table?.columns.length).toBe(2);
+    });
+
+    test('릴레이션을 업데이트합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createRelation(relation);
+
+      const updatedRelation: ERDRelation = { ...relation, type: 'one-to-many' };
+      store.getState().updateRelation(updatedRelation);
+
+      const updatedRel = store
+        .getState()
+        .relations[table1.id].find((rel) => rel.id === relation.id);
+      expect(updatedRel?.type).toBe('one-to-many');
+    });
+
+    test('릴레이션의 식별/비식별이 변경되면, 다른 테이블에 영향을 미치게됩니다. 식별 → 비식별', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createRelation(relation);
+
+      const beforeTable2 = store
+        .getState()
+        .tables.find((table) => table.id === relation.to);
+
+      expect(beforeTable2?.columns.length).toBe(1);
+      expect(beforeTable2?.columns[0].keyType).toBe('pk/fk');
+
+      store.getState().updateRelation({ ...relation, identify: false });
+
+      const afterTable2 = store
+        .getState()
+        .tables.find((table) => table.id === relation.to);
+
+      expect(afterTable2?.columns.length).toBe(1);
+      expect(afterTable2?.columns[0].keyType).toBe('fk');
+    });
+
+    test('릴레이션의 식별/비식별이 변경되면, 다른 테이블에 영향을 미치게됩니다. 비식별 → 식별', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createRelation({ ...relation, identify: false });
+
+      const beforeTable2 = store
+        .getState()
+        .tables.find((table) => table.id === relation.to);
+
+      expect(beforeTable2?.columns.length).toBe(1);
+      expect(beforeTable2?.columns[0].keyType).toBe('fk');
+
       store.getState().updateRelation({ ...relation, identify: true });
 
-      const target = store
+      const afterTable2 = store
         .getState()
-        .relations[table1.id].find((v) => v.id === relation.id);
+        .tables.find((table) => table.id === relation.to);
 
-      expect(target).not.toBeUndefined();
-      expect(target?.identify).toBe(true);
+      expect(afterTable2?.columns.length).toBe(1);
+      expect(afterTable2?.columns[0].keyType).toBe('pk/fk');
     });
 
-    test('Relation 삭제가 정상적으로 이루어져야 합니다.', () => {
+    test('릴레이션을 삭제합니다.', () => {
       const store = createERDProjectStore();
-
       store.getState().createTable(table1);
       store.getState().createTable(table2);
       store.getState().createRelation(relation);
+
       store.getState().deleteRelation(relation);
 
-      expect(store.getState().relations[table1.id]).not.toBeUndefined();
-      expect(store.getState().relations[table2.id]).not.toBeUndefined();
       expect(store.getState().relations[table1.id].length).toBe(0);
       expect(store.getState().relations[table2.id].length).toBe(0);
+    });
+
+    test('릴레이션을 삭제하면, 다른 테이블의 컬럼에 영향을 미칩니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createColumn(table2, true);
+      store.getState().createRelation(relation);
+
+      const table = store
+        .getState()
+        .tables.find((table) => table.title === 'Table 2');
+
+      expect(table).not.toBeUndefined();
+      expect(table?.columns.length).toBe(2);
+
+      store.getState().deleteRelation(relation);
+
+      const updatedTable = store
+        .getState()
+        .tables.find((table) => table.title === 'Table 2');
+      expect(updatedTable?.columns.length).toBe(1);
     });
   });
 });

--- a/src/__tests__/jest.test.ts
+++ b/src/__tests__/jest.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, test } from '@jest/globals';
-
-describe('Jest 실행 테스트 파일', () => {
-  test('1+2=3', () => {
-    expect(1 + 2).toBe(3);
-  });
-});

--- a/src/features/erd-project/erd-project.slice.ts
+++ b/src/features/erd-project/erd-project.slice.ts
@@ -1,24 +1,32 @@
+import { v4 as uuidv4 } from 'uuid';
 import { createStore } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+
+type KeyType = 'pk' | 'fk' | 'pk/fk';
 
 export interface ERDColumn {
-  type: string;
+  id: string;
+  type?: string;
   name: string;
   nullable: boolean;
+  keyType?: KeyType;
 }
 
 export interface ERDTable {
   id: string;
+  title: string;
   top: number;
   left: number;
   width: number;
   height: number;
+  columns: ERDColumn[];
 }
 
 export interface ERDRelation {
   id: string;
   from: ERDTable['id'];
   to: ERDTable['id'];
-  type: 'one-to-one' | 'one-to-many' | 'many-to-many';
+  type: 'one-to-one' | 'one-to-many';
   identify: boolean;
   multiplicity?: {
     from?: 'optional' | 'mandatory';
@@ -40,12 +48,15 @@ export interface ERDProjectAction {
   setProject: (project: ERDProject) => void;
   updateDescriptions: (metaData: {
     title: string;
-    description: string;
+    description?: string;
   }) => void;
   updateCanvasSize: (size: { width: number; height: number }) => void;
   createTable: (table: ERDTable) => void;
   updateTable: (table: ERDTable) => void;
   deleteTable: (tableId: ERDTable['id']) => void;
+  createColumn: (table: ERDTable, isPK: boolean) => void;
+  updateColumn: (table: ERDTable, column: ERDColumn) => void;
+  deleteColumn: (table: ERDTable, column: ERDColumn) => void;
   createRelation: (relation: ERDRelation) => void;
   updateRelation: (relation: ERDRelation) => void;
   deleteRelation: (relation: ERDRelation) => void;
@@ -66,74 +77,306 @@ export const defaultInitState: ERDProject = {
 export const createERDProjectStore = (
   initState: ERDProject = defaultInitState,
 ) =>
-  createStore<ERDProjectStore>()((set) => ({
-    ...initState,
-    setProject: (project) => set(project),
-    updateDescriptions: ({ title, description }) =>
-      set((prev) => ({ ...prev, title, description })),
-    updateCanvasSize: ({ width, height }) => {
-      if (width <= 0 || height <= 0)
-        throw new Error('width, height must greater than 0');
-      set((prev) => ({ ...prev, width, height }));
-    },
-    createTable: (table) =>
-      set((prev) => ({ ...prev, tables: prev.tables.concat(table) })),
-    updateTable: (table: ERDTable) =>
-      set((prev) => ({
-        ...prev,
-        tables: prev.tables.map((t) => (t.id === table.id ? table : t)),
-      })),
-    deleteTable: (tableId) =>
-      set((prev) => ({
-        ...prev,
-        tables: prev.tables.filter((table) => table.id !== tableId),
-      })),
-    createRelation: (relation) => {
-      if (relation.type === 'one-to-one' || relation.type === 'one-to-many') {
-        set((prev) => ({
-          ...prev,
-          relations: {
-            ...prev.relations,
-            [relation.to]: [...(prev.relations[relation.to] ?? []), relation],
-            [relation.from]: [
-              ...(prev.relations[relation.from] ?? []),
-              relation,
-            ],
-          },
-        }));
-      } else {
-        // 여기가 좀 애매합니다.
-        // 서버로 새로운 테이블을 생성해야하는데, API 요청을 여기서 하면 의존관계가 이상해집니다.
-      }
-    },
-    updateRelation: (relation) => {
-      if (relation.type === 'many-to-many')
-        throw new Error('it cannot be many-to-many');
+  createStore<ERDProjectStore>()(
+    immer((set) => ({
+      ...initState,
 
-      set((prev) => ({
-        ...prev,
-        relations: {
-          ...prev.relations,
-          [relation.to]: prev.relations[relation.to].map((v) =>
-            v.id === relation.id ? relation : v,
-          ),
-          [relation.from]: prev.relations[relation.from].map((v) =>
-            v.id === relation.id ? relation : v,
-          ),
-        },
-      }));
-    },
-    deleteRelation: (relation) =>
-      set((prev) => ({
-        ...prev,
-        relations: {
-          ...prev.relations,
-          [relation.to]: prev.relations[relation.to].filter(
-            (v) => v.id !== relation.id,
-          ),
-          [relation.from]: prev.relations[relation.from].filter(
-            (v) => v.id !== relation.id,
-          ),
-        },
-      })),
-  }));
+      setProject: (project) =>
+        set((state) => {
+          state.id = project.id;
+          state.title = project.title;
+          state.description = project.description;
+          state.width = project.width;
+          state.height = project.height;
+          state.tables = project.tables;
+          state.relations = project.relations;
+        }),
+
+      updateDescriptions: ({ title, description }) =>
+        set((state) => {
+          state.title = title;
+          state.description = description;
+        }),
+
+      updateCanvasSize: ({ width, height }) => {
+        if (width <= 0 || height <= 0)
+          throw new Error('width, height must greater than 0');
+
+        set((state) => {
+          state.width = width;
+          state.height = height;
+        });
+      },
+
+      createTable: (table) =>
+        set((state) => {
+          state.tables.push(table);
+        }),
+
+      updateTable: (table) =>
+        set((state) => {
+          state.tables = state.tables.map((v) =>
+            v.id === table.id ? table : v,
+          );
+        }),
+
+      deleteTable: (tableId) =>
+        set((state) => {
+          state.tables = state.tables.filter((v) => v.id !== tableId);
+        }),
+
+      createColumn: (table, isPK = false) =>
+        set(({ tables, relations }) => {
+          const target = tables.find((v) => v.id === table.id);
+          if (!target) throw new Error('table not found');
+
+          const column: ERDColumn = {
+            id: uuidv4(),
+            name: 'column',
+            nullable: false,
+            keyType: isPK ? 'pk' : undefined,
+          };
+
+          target.columns.push(column);
+
+          if (!isPK) return;
+
+          const visited: Record<ERDTable['id'], boolean> = {};
+
+          const dfs = (curr: ERDTable) => {
+            if (visited[curr.id]) return;
+
+            visited[curr.id] = true;
+            relations[curr.id]
+              ?.filter((relation) => relation.from === curr.id)
+              ?.forEach((relation) => {
+                const next = tables.find((t) => t.id === relation.to);
+                if (!next) return;
+
+                next.columns.push({
+                  ...column,
+                  keyType: relation.identify ? 'pk/fk' : 'fk',
+                });
+                dfs(next);
+              });
+          };
+
+          dfs(target);
+        }),
+
+      updateColumn: (table, column) =>
+        set((state) => {
+          const targetTable = state.tables.find((t) => t.id === table.id);
+          if (!targetTable) return;
+
+          const targetColumn = targetTable.columns.find(
+            (c) => c.id === column.id,
+          );
+          if (!targetColumn) return;
+
+          targetColumn.name = column.name;
+          targetColumn.type = column.type;
+          targetColumn.keyType = column.keyType;
+          targetColumn.nullable = column.nullable;
+
+          const visited: Record<ERDTable['id'], boolean> = {};
+
+          const dfs = (curr: ERDTable) => {
+            if (visited[curr.id]) return;
+
+            visited[curr.id] = true;
+            state.relations[curr.id]
+              ?.filter((rel) => rel.from === curr.id)
+              ?.forEach((rel) => {
+                const next = state.tables.find((t) => t.id === rel.to);
+                if (!next) return;
+
+                const keyType = rel.identify ? 'pk/fk' : 'fk';
+                curr.columns
+                  .filter((col) => col.id === column.id)
+                  .forEach((col) => {
+                    const nextCol = next.columns.find((c) => c.id === col.id);
+                    if (nextCol) {
+                      nextCol.name = column.name;
+                      nextCol.type = column.type;
+                      nextCol.keyType = keyType;
+                      nextCol.nullable = column.nullable;
+                    }
+                  });
+
+                dfs(next);
+              });
+          };
+
+          dfs(targetTable);
+        }),
+
+      deleteColumn: (table, column) =>
+        set((state) => {
+          const targetTable = state.tables.find((t) => t.id === table.id);
+          if (!targetTable) return;
+
+          const targetColumn = targetTable.columns.find(
+            (c) => c.id === column.id,
+          );
+          if (!targetColumn) return;
+
+          targetTable.columns = targetTable.columns.filter(
+            (c) => c.id !== column.id,
+          );
+
+          if (column.keyType === 'pk') {
+            const visited: Record<ERDTable['id'], boolean> = {};
+
+            const dfs = (curr: ERDTable) => {
+              if (visited[curr.id]) return;
+
+              visited[curr.id] = true;
+              state.relations[curr.id]
+                ?.filter((rel) => rel.from === curr.id)
+                ?.forEach((rel) => {
+                  const next = state.tables.find((t) => t.id === rel.to);
+                  if (!next) return;
+
+                  next.columns = next.columns.filter((c) => c.id !== column.id);
+                  dfs(next);
+                });
+            };
+
+            dfs(targetTable);
+          }
+        }),
+
+      createRelation: (relation) =>
+        set(({ tables, relations }) => {
+          const from = tables.find((table) => table.id === relation.from);
+          const to = tables.find((table) => table.id === relation.to);
+
+          if (!from || !to) return;
+
+          if (!relations[relation.from]) relations[relation.from] = [];
+          if (!relations[relation.to]) relations[relation.to] = [];
+          relations[relation.from].push(relation);
+          relations[relation.to].push(relation);
+
+          const visited: Record<ERDTable['id'], boolean> = {};
+
+          const dfs = (curr: ERDTable) => {
+            if (visited[curr.id]) return;
+
+            visited[curr.id] = true;
+            relations[curr.id]
+              ?.filter((rel) => rel.from === curr.id)
+              ?.forEach((rel) => {
+                const next = tables.find((t) => t.id === rel.to);
+                if (!next) return;
+
+                const keyType = rel.identify ? 'pk/fk' : 'fk';
+                from.columns
+                  .filter((col) => col.keyType === 'pk')
+                  .forEach((col) => {
+                    next.columns.push({
+                      ...col,
+                      keyType,
+                    });
+                  });
+
+                dfs(next);
+              });
+          };
+
+          dfs(from);
+        }),
+
+      updateRelation: (relation) =>
+        set((state) => {
+          const updateRelationInState = (rel: ERDRelation) =>
+            rel.id === relation.id ? relation : rel;
+
+          state.relations[relation.from] = state.relations[relation.from].map(
+            updateRelationInState,
+          );
+          state.relations[relation.to] = state.relations[relation.to].map(
+            updateRelationInState,
+          );
+
+          const visited: Record<ERDRelation['id'], boolean> = {};
+
+          const dfs = (erdRelation: ERDRelation) => {
+            if (visited[erdRelation.id]) return;
+
+            visited[erdRelation.id] = true;
+
+            const fromTable = state.tables.find(
+              (table) => table.id === erdRelation.from,
+            );
+            const toTable = state.tables.find(
+              (table) => table.id === erdRelation.to,
+            );
+
+            if (!fromTable || !toTable) return;
+
+            fromTable.columns
+              .filter((col) => col.keyType === 'pk')
+              .forEach((col1) => {
+                toTable.columns = toTable.columns.map((col2) =>
+                  col2.id === col1.id
+                    ? {
+                        ...col2,
+                        keyType: erdRelation.identify ? 'pk/fk' : 'fk',
+                      }
+                    : col2,
+                );
+              });
+
+            state.relations[erdRelation.to]
+              .filter((rel) => rel.from === erdRelation.to)
+              .forEach(dfs);
+          };
+
+          dfs(relation);
+        }),
+
+      deleteRelation: (relation) =>
+        set((state) => {
+          const visited: Record<ERDRelation['id'], boolean> = {};
+
+          const dfs = (erdRelation: ERDRelation) => {
+            if (visited[erdRelation.id]) return;
+
+            visited[erdRelation.id] = true;
+
+            const fromTable = state.tables.find(
+              (table) => table.id === erdRelation.from,
+            );
+            const toTable = state.tables.find(
+              (table) => table.id === erdRelation.to,
+            );
+
+            if (!fromTable || !toTable) return;
+
+            fromTable.columns
+              .filter((col) => col.keyType === 'pk')
+              .forEach((col1) => {
+                toTable.columns = toTable.columns.filter(
+                  (col2) => col2.id !== col1.id,
+                );
+              });
+
+            state.relations[erdRelation.to]
+              .filter((rel) => rel.from === erdRelation.to)
+              .forEach(dfs);
+          };
+
+          dfs(relation);
+
+          state.relations[relation.from] = state.relations[
+            relation.from
+          ].filter((rel) => rel.id !== relation.id);
+
+          state.relations[relation.to] = state.relations[relation.to].filter(
+            (rel) => rel.id !== relation.id,
+          );
+        }),
+    })),
+  );

--- a/src/features/erd-project/erd-project.slice.ts
+++ b/src/features/erd-project/erd-project.slice.ts
@@ -1,0 +1,139 @@
+import { createStore } from 'zustand';
+
+export interface ERDColumn {
+  type: string;
+  name: string;
+  nullable: boolean;
+}
+
+export interface ERDTable {
+  id: string;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export interface ERDRelation {
+  id: string;
+  from: ERDTable['id'];
+  to: ERDTable['id'];
+  type: 'one-to-one' | 'one-to-many' | 'many-to-many';
+  identify: boolean;
+  multiplicity?: {
+    from?: 'optional' | 'mandatory';
+    to?: 'optional' | 'mandatory';
+  };
+}
+
+export interface ERDProject {
+  id: string;
+  title: string;
+  description?: string;
+  width: number;
+  height: number;
+  tables: ERDTable[];
+  relations: Record<ERDTable['id'], ERDRelation[]>;
+}
+
+export interface ERDProjectAction {
+  setProject: (project: ERDProject) => void;
+  updateDescriptions: (metaData: {
+    title: string;
+    description: string;
+  }) => void;
+  updateCanvasSize: (size: { width: number; height: number }) => void;
+  createTable: (table: ERDTable) => void;
+  updateTable: (table: ERDTable) => void;
+  deleteTable: (tableId: ERDTable['id']) => void;
+  createRelation: (relation: ERDRelation) => void;
+  updateRelation: (relation: ERDRelation) => void;
+  deleteRelation: (relation: ERDRelation) => void;
+}
+
+export type ERDProjectStore = ERDProject & ERDProjectAction;
+
+export const defaultInitState: ERDProject = {
+  id: 'default',
+  title: '프로젝트 이름',
+  description: undefined,
+  height: 0,
+  width: 0,
+  tables: [],
+  relations: {},
+};
+
+export const createERDProjectStore = (
+  initState: ERDProject = defaultInitState,
+) =>
+  createStore<ERDProjectStore>()((set) => ({
+    ...initState,
+    setProject: (project) => set(project),
+    updateDescriptions: ({ title, description }) =>
+      set((prev) => ({ ...prev, title, description })),
+    updateCanvasSize: ({ width, height }) => {
+      if (width <= 0 || height <= 0)
+        throw new Error('width, height must greater than 0');
+      set((prev) => ({ ...prev, width, height }));
+    },
+    createTable: (table) =>
+      set((prev) => ({ ...prev, tables: prev.tables.concat(table) })),
+    updateTable: (table: ERDTable) =>
+      set((prev) => ({
+        ...prev,
+        tables: prev.tables.map((t) => (t.id === table.id ? table : t)),
+      })),
+    deleteTable: (tableId) =>
+      set((prev) => ({
+        ...prev,
+        tables: prev.tables.filter((table) => table.id !== tableId),
+      })),
+    createRelation: (relation) => {
+      if (relation.type === 'one-to-one' || relation.type === 'one-to-many') {
+        set((prev) => ({
+          ...prev,
+          relations: {
+            ...prev.relations,
+            [relation.to]: [...(prev.relations[relation.to] ?? []), relation],
+            [relation.from]: [
+              ...(prev.relations[relation.from] ?? []),
+              relation,
+            ],
+          },
+        }));
+      } else {
+        // 여기가 좀 애매합니다.
+        // 서버로 새로운 테이블을 생성해야하는데, API 요청을 여기서 하면 의존관계가 이상해집니다.
+      }
+    },
+    updateRelation: (relation) => {
+      if (relation.type === 'many-to-many')
+        throw new Error('it cannot be many-to-many');
+
+      set((prev) => ({
+        ...prev,
+        relations: {
+          ...prev.relations,
+          [relation.to]: prev.relations[relation.to].map((v) =>
+            v.id === relation.id ? relation : v,
+          ),
+          [relation.from]: prev.relations[relation.from].map((v) =>
+            v.id === relation.id ? relation : v,
+          ),
+        },
+      }));
+    },
+    deleteRelation: (relation) =>
+      set((prev) => ({
+        ...prev,
+        relations: {
+          ...prev.relations,
+          [relation.to]: prev.relations[relation.to].filter(
+            (v) => v.id !== relation.id,
+          ),
+          [relation.from]: prev.relations[relation.from].filter(
+            (v) => v.id !== relation.id,
+          ),
+        },
+      })),
+  }));

--- a/src/features/erd-project/erd-project.slice.ts
+++ b/src/features/erd-project/erd-project.slice.ts
@@ -122,6 +122,32 @@ export const createERDProjectStore = (
 
       deleteTable: (tableId) =>
         set((state) => {
+          const target = state.tables.find((v) => v.id === tableId);
+          if (!target) return;
+
+          const visited: Record<ERDTable['id'], boolean> = {};
+
+          const dfs = (curr: ERDTable) => {
+            if (visited[curr.id]) return;
+
+            visited[curr.id] = true;
+
+            state.relations[curr.id]
+              ?.filter((relation) => relation.from === curr.id)
+              ?.forEach((relation) => {
+                const next = state.tables.find((t) => t.id === relation.to);
+                if (!next) return;
+
+                next.columns = next.columns.filter(
+                  (col) => !curr.columns.some((c) => c.id === col.id),
+                );
+
+                dfs(next);
+              });
+          };
+
+          dfs(target);
+
           state.tables = state.tables.filter((v) => v.id !== tableId);
         }),
 

--- a/src/features/erd-project/index.ts
+++ b/src/features/erd-project/index.ts
@@ -1,0 +1,1 @@
+export * from './erd-project.slice';


### PR DESCRIPTION
## Overview

- ERD 데이터를 다루기 위한, 상태와 액션이 구현되었습니다.
  - 테이블 삭제
    - 테이블 삭제시, 연관된 릴레이션에 따라 컬럼을 제거합니다.
  - 릴레이션 추가
    - 릴레이션 추가시, 연관된 릴레이션에 따라 컬럼을 추가합니다.
  - 릴레이션 업데이트
    - 릴레이션 업데이트시, 연관된 릴레이션에 따라 식별/비식별 데이터가 업데이트 되면 해당 변경에 따라 컬럼을 변경합니다.
  - 릴레이션 삭제
    - 릴레이션 삭제시, 연관된 릴레이션에 따라 컬럼을 삭제합니다.
  - 컬럼 추가
    - 컬럼 추가시, 연관된 릴레이션에 따라 다른 테이블에 컬럼을 추가합니다.
  - 컬럼 업데이트
    - 컬럼 업데이트시, 연관된 릴레이션에 따라 다른 테이블에도 컬럼이 변경됩니다.
  - 컬럼 삭제
    - 컬럼 삭제시, 연관된 릴레이션에 따라 다른 테이블에도 컬럼이 삭제됩니다.
  - 사이클 감지 부분이 현재 미구현 상태입니다. 해당 부분 참고해서 작업바랍니다.
    - 사이클 감지 관련해서는 이후에 추가 작업하여 사이클 탐지시, 비식별 관계로 연결하는 방식으로 추가 예정입니다.
  - 이 외에 액션에서는 기초적인 작업만 진행합니다.
- 테스트를 포함하고 있습니다.

## Issues

- #19 