### PR TITLE
[FLOW-1] fix: update relation multiplicity for foreign key columns

### DIFF
--- a/src/__tests__/erd-project.slice.test.ts
+++ b/src/__tests__/erd-project.slice.test.ts
@@ -245,6 +245,252 @@ describe('ERD Project Store', () => {
       expect(updatedColumn2!.name).toBe('test-name');
     });
 
+    test('테이블2의 FK인 컬럼이 nullable로 변경되면, 테이블1과의 관계의 참여 정보가 부분참여로 변경되어야합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createRelation({
+        ...relation,
+        identify: false,
+        multiplicity: {
+          from: 'optional',
+          to: 'mandatory',
+        },
+      });
+
+      const targetColumn = store
+        .getState()
+        .tables.find((t) => t.id === table2.id)?.columns[0];
+
+      expect(targetColumn).not.toBeUndefined();
+      expect(targetColumn!.nullable).toBe(false);
+
+      store
+        .getState()
+        .updateColumn(table2, { ...targetColumn!, nullable: true });
+
+      const targetRelation = store
+        .getState()
+        .relations[table2.id].find((rel) => rel.id === relation.id);
+
+      expect(targetRelation).not.toBeUndefined();
+      expect(targetRelation!.multiplicity!.to).toBe('optional');
+    });
+
+    test('테이블2의 FK인 컬럼이 nullable에서 non-null로 변경되면, 테이블1과의 관계의 참여 정보가 전체참여로 변경되어야합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createRelation({
+        ...relation,
+        identify: false,
+        multiplicity: {
+          from: 'optional',
+          to: 'mandatory',
+        },
+      });
+
+      const targetColumn = store
+        .getState()
+        .tables.find((t) => t.id === table2.id)?.columns[0];
+
+      store
+        .getState()
+        .updateColumn(table2, { ...targetColumn!, nullable: true });
+
+      const updatedColumn = store
+        .getState()
+        .tables.find((t) => t.id === table2.id)?.columns[0];
+
+      expect(updatedColumn).not.toBeUndefined();
+      expect(updatedColumn!.nullable).toBe(true);
+
+      store
+        .getState()
+        .updateColumn(table2, { ...updatedColumn!, nullable: false });
+
+      const targetRelation = store
+        .getState()
+        .relations[table2.id].find((rel) => rel.id === relation.id);
+
+      expect(targetRelation).not.toBeUndefined();
+      expect(targetRelation!.multiplicity!.to).toBe('mandatory');
+    });
+
+    test('테이블2의 FK인 컬럼이 여러 개이고, 이 중 모두가 nullable로 변경되면, 테이블1과의 관계의 참여 정보가 부분참여로 변경되어야합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createColumn(table1, true);
+      store.getState().createRelation({
+        ...relation,
+        identify: false,
+        multiplicity: {
+          from: 'optional',
+          to: 'mandatory',
+        },
+      });
+
+      const targetColumns = store
+        .getState()
+        .tables.find((t) => t.id === table2.id)
+        ?.columns.filter((col) => col.keyType === 'fk');
+
+      expect(targetColumns).not.toBeUndefined();
+      targetColumns?.forEach((col) => {
+        expect(col.nullable).toBe(false);
+      });
+
+      targetColumns?.forEach((col) => {
+        store.getState().updateColumn(table2, { ...col, nullable: true });
+      });
+
+      const targetRelation = store
+        .getState()
+        .relations[table2.id].find((rel) => rel.id === relation.id);
+
+      expect(targetRelation).not.toBeUndefined();
+      expect(targetRelation!.multiplicity!.to).toBe('optional');
+    });
+
+    test('테이블2의 FK인 컬럼이 여러 개이고, 이 중 하나만 nullable로 변경되면, 테이블1과의 관계의 참여 정보가 변경되지 않아야 합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createColumn(table1, true);
+      store.getState().createRelation({
+        ...relation,
+        identify: false,
+        multiplicity: {
+          from: 'optional',
+          to: 'mandatory',
+        },
+      });
+
+      const targetColumns = store
+        .getState()
+        .tables.find((t) => t.id === table2.id)
+        ?.columns.filter((col) => col.keyType === 'fk');
+
+      expect(targetColumns).not.toBeUndefined();
+      targetColumns?.forEach((col) => {
+        expect(col.nullable).toBe(false);
+      });
+
+      targetColumns?.forEach((col, index) => {
+        if (index > 0) return;
+        store.getState().updateColumn(table2, { ...col, nullable: true });
+      });
+
+      const targetRelation = store
+        .getState()
+        .relations[table2.id].find((rel) => rel.id === relation.id);
+
+      expect(targetRelation).not.toBeUndefined();
+      expect(targetRelation!.multiplicity!.to).toBe('mandatory');
+    });
+
+    test('테이블2의 FK인 컬럼이 여러 개이고, 이 중 모두가 non-null로 변겯되면, 테이블1과의 관계의 참여 정보가 전체참여로 변경되어야합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createColumn(table1, true);
+      store.getState().createRelation({
+        ...relation,
+        identify: false,
+        multiplicity: {
+          from: 'optional',
+          to: 'mandatory',
+        },
+      });
+
+      const targetColumns = store
+        .getState()
+        .tables.find((t) => t.id === table2.id)
+        ?.columns.filter((col) => col.keyType === 'fk');
+
+      expect(targetColumns).not.toBeUndefined();
+      targetColumns?.forEach((col) => {
+        expect(col.nullable).toBe(false);
+      });
+
+      targetColumns?.forEach((col) => {
+        store.getState().updateColumn(table2, { ...col, nullable: true });
+      });
+
+      const targetRelation = store
+        .getState()
+        .relations[table2.id].find((rel) => rel.id === relation.id);
+
+      expect(targetRelation).not.toBeUndefined();
+      expect(targetRelation!.multiplicity!.to).toBe('optional');
+
+      targetColumns?.forEach((col) => {
+        store.getState().updateColumn(table2, { ...col, nullable: false });
+      });
+
+      const updatedRelation = store
+        .getState()
+        .relations[table2.id].find((rel) => rel.id === relation.id);
+
+      expect(updatedRelation).not.toBeUndefined();
+      expect(updatedRelation!.multiplicity!.to).toBe('mandatory');
+    });
+
+    test('테이블2의 FK인 컬럼이 여러 개이고, 이 중 하나만 non-null로 변경되면, 테이블1과의 관계의 참여 정보가 전체참여로 유지되어야 합니다.', () => {
+      const store = createERDProjectStore();
+      store.getState().createTable(table1);
+      store.getState().createTable(table2);
+      store.getState().createColumn(table1, true);
+      store.getState().createColumn(table1, true);
+      store.getState().createRelation({
+        ...relation,
+        identify: false,
+        multiplicity: {
+          from: 'optional',
+          to: 'mandatory',
+        },
+      });
+
+      const targetColumns = store
+        .getState()
+        .tables.find((t) => t.id === table2.id)
+        ?.columns.filter((col) => col.keyType === 'fk');
+
+      expect(targetColumns).not.toBeUndefined();
+      targetColumns?.forEach((col) => {
+        expect(col.nullable).toBe(false);
+      });
+
+      targetColumns?.forEach((col) => {
+        store.getState().updateColumn(table2, { ...col, nullable: true });
+      });
+
+      const targetRelation = store
+        .getState()
+        .relations[table2.id].find((rel) => rel.id === relation.id);
+
+      expect(targetRelation).not.toBeUndefined();
+      expect(targetRelation!.multiplicity!.to).toBe('optional');
+
+      targetColumns?.forEach((col, index) => {
+        if (index > 0) return;
+        store.getState().updateColumn(table2, { ...col, nullable: false });
+      });
+
+      const updatedRelation = store
+        .getState()
+        .relations[table2.id].find((rel) => rel.id === relation.id);
+
+      expect(updatedRelation).not.toBeUndefined();
+      expect(updatedRelation!.multiplicity!.to).toBe('mandatory');
+    });
+
     test('컬럼을 삭제합니다.', () => {
       const store = createERDProjectStore();
       store.getState().createTable(table1);

--- a/src/__tests__/erd-project.slice.test.ts
+++ b/src/__tests__/erd-project.slice.test.ts
@@ -394,7 +394,7 @@ describe('ERD Project Store', () => {
       expect(targetRelation!.multiplicity!.to).toBe('mandatory');
     });
 
-    test('테이블2의 FK인 컬럼이 여러 개이고, 이 중 모두가 non-null로 변겯되면, 테이블1과의 관계의 참여 정보가 전체참여로 변경되어야합니다.', () => {
+    test('테이블2의 FK인 컬럼이 여러 개이고, 이 중 모두가 non-null로 변경되면, 테이블1과의 관계의 참여 정보가 전체참여로 변경되어야합니다.', () => {
       const store = createERDProjectStore();
       store.getState().createTable(table1);
       store.getState().createTable(table2);

--- a/src/features/erd-project/erd-project.slice.ts
+++ b/src/features/erd-project/erd-project.slice.ts
@@ -226,7 +226,6 @@ export const createERDProjectStore = (
                       nextCol.name = column.name;
                       nextCol.type = column.type;
                       nextCol.keyType = keyType;
-                      nextCol.nullable = column.nullable;
                     }
                   });
 

--- a/src/features/erd-project/erd-project.slice.ts
+++ b/src/features/erd-project/erd-project.slice.ts
@@ -240,8 +240,15 @@ export const createERDProjectStore = (
               const toTable = state.tables.find((t) => t.id === rel.to);
               if (!toTable) return;
 
+              const fromTable = state.tables.find((t) => t.id === rel.from);
+              if (!fromTable) return;
+
               const allFKsNullable = toTable.columns
                 .filter((col) => col.keyType === 'fk')
+                .filter(
+                  (col) =>
+                    fromTable.columns.find((c) => c.id === col.id) !== null,
+                )
                 .every((col) => col.nullable);
 
               if (allFKsNullable) {

--- a/src/features/erd-project/erd-project.slice.ts
+++ b/src/features/erd-project/erd-project.slice.ts
@@ -234,6 +234,33 @@ export const createERDProjectStore = (
           };
 
           dfs(targetTable);
+
+          if (column.keyType === 'fk') {
+            const updateRelationMultiplicity = (rel: ERDRelation) => {
+              const toTable = state.tables.find((t) => t.id === rel.to);
+              if (!toTable) return;
+
+              const allFKsNullable = toTable.columns
+                .filter((col) => col.keyType === 'fk')
+                .every((col) => col.nullable);
+
+              if (allFKsNullable) {
+                rel.multiplicity = {
+                  ...rel.multiplicity,
+                  to: 'optional',
+                };
+              } else {
+                rel.multiplicity = {
+                  ...rel.multiplicity,
+                  to: 'mandatory',
+                };
+              }
+            };
+
+            state.relations[targetTable.id]?.forEach(
+              updateRelationMultiplicity,
+            );
+          }
         }),
 
       deleteColumn: (table, column) =>


### PR DESCRIPTION
## Overview

- nullable 옵션이 변경된 경우 전파되는 문제를 해결했습니다.
- FK 컬럼이 변경될 경우 참여 정보가 아래 경우에 따라 업데이트 되도록 수정했습니다.
  - FK인 컬럼이 1개이고, nullable이 된 경우, 해당 관계가 부분 참여로 변경됩니다.
  - FK인 컬럼이 1개이고, nullable에서 non-null이 된 경우, 해당 관계가 전체 참여로 변경됩니다.
  - FK인 컬럼이 2개 이상이고, 모두 nullable이 된 경우, 해당 관계가 부분 참여로 변경됩니다.
  - FK인 컬럼이 2개 이상이고, 하나만 nullable이 된 경우, 해당 관계가 전체 참여로 유지됩니다.
  - FK인 컬럼이 2개 이상이고, 모두 nullable에서 non-null이 된 경우, 해당 관계가 부분 참여로 변경됩니다.
  - FK인 컬럼이 2개 이상이고, 하나만 nullable에서 non-null이 된 경우, 해당 관계가 전체 참여로 유지됩니다.
  - 위 경우에 대한 테스트 케이스를 포함합니다.
