### PR TITLE
[FLOW-18] refactor: modify to use useERDProjectStore instead of useStore

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 
 import './globals.css';
-import { TanStackQueryProvider } from '@/providers';
+import { ERDProjectProvider, TanStackQueryProvider } from '@/providers';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -19,7 +19,9 @@ export default function RootLayout({
   return (
     <html lang='ko-kr'>
       <body className={inter.className}>
-        <TanStackQueryProvider>{children}</TanStackQueryProvider>
+        <TanStackQueryProvider>
+          <ERDProjectProvider>{children}</ERDProjectProvider>
+        </TanStackQueryProvider>
       </body>
     </html>
   );

--- a/src/page/erd-project.page.tsx
+++ b/src/page/erd-project.page.tsx
@@ -2,33 +2,31 @@
 
 import styled from '@emotion/styled';
 import { useState } from 'react';
-import { useStore } from 'zustand';
 
 import {
-  TableInformation,
   ErdDrawTools,
   RelationshipInformation,
+  TableInformation,
 } from '@/components';
 import { Relationship } from '@/components/Relationship';
 import { Table } from '@/components/table';
 import { useDrawToolsStore } from '@/features/draw-tools';
-import { createERDProjectStore, ERDTable } from '@/features/erd-project';
-
-const store = createERDProjectStore();
+import { ERDTable } from '@/features/erd-project';
+import { useERDProjectStore } from '@/providers';
 
 export function ErdProjectPage() {
-  const tables = useStore(store, (state) => state.tables);
-  const relations = useStore(store, (state) => state.relations);
+  const tables = useERDProjectStore((state) => state.tables);
+  const relations = useERDProjectStore((state) => state.relations);
 
-  const createTable = useStore(store, (state) => state.createTable);
-  const deleteTable = useStore(store, (state) => state.deleteTable);
-  const updateTable = useStore(store, (state) => state.updateTable);
+  const createTable = useERDProjectStore((state) => state.createTable);
+  const deleteTable = useERDProjectStore((state) => state.deleteTable);
+  const updateTable = useERDProjectStore((state) => state.updateTable);
 
-  const createRelation = useStore(store, (state) => state.createRelation);
+  const createRelation = useERDProjectStore((state) => state.createRelation);
 
-  const createColumn = useStore(store, (state) => state.createColumn);
-  const deleteColumn = useStore(store, (state) => state.deleteColumn);
-  const updateColumn = useStore(store, (state) => state.updateColumn);
+  const createColumn = useERDProjectStore((state) => state.createColumn);
+  const deleteColumn = useERDProjectStore((state) => state.deleteColumn);
+  const updateColumn = useERDProjectStore((state) => state.updateColumn);
 
   const mapping = useDrawToolsStore((state) => state.mapping);
   const setMapping = useDrawToolsStore((state) => state.setMapping);

--- a/src/providers/ERDProjectProvider.tsx
+++ b/src/providers/ERDProjectProvider.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { createContext, PropsWithChildren, useContext, useRef } from 'react';
+import { useStore } from 'zustand';
 
-import { createERDProjectStore } from '@/features/erd-project';
+import { createERDProjectStore, ERDProjectStore } from '@/features/erd-project';
 
 export type ERDProjectStoreAPI = ReturnType<typeof createERDProjectStore>;
 
@@ -25,7 +26,9 @@ export function ERDProjectProvider({ children }: ERDProjectProviderProps) {
   );
 }
 
-export const useERDProjectStore = () => {
+export const useERDProjectStore = <T,>(
+  selector: (store: ERDProjectStore) => T,
+): T => {
   const store = useContext(ERDProjectContext);
 
   if (!store) {
@@ -33,6 +36,6 @@ export const useERDProjectStore = () => {
       'useERDProjectStore must be used within a ERDProjectProvider',
     );
   }
-  
-  return store;
+
+  return useStore(store, selector);
 };

--- a/src/providers/ERDProjectProvider.tsx
+++ b/src/providers/ERDProjectProvider.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { createContext, PropsWithChildren, useContext, useRef } from 'react';
+
+import { createERDProjectStore } from '@/features/erd-project';
+
+export type ERDProjectStoreAPI = ReturnType<typeof createERDProjectStore>;
+
+export const ERDProjectContext = createContext<ERDProjectStoreAPI | undefined>(
+  undefined,
+);
+
+export type ERDProjectProviderProps = PropsWithChildren;
+
+export function ERDProjectProvider({ children }: ERDProjectProviderProps) {
+  const storeRef = useRef<ERDProjectStoreAPI>();
+  if (!storeRef.current) {
+    storeRef.current = createERDProjectStore();
+  }
+
+  return (
+    <ERDProjectContext.Provider value={storeRef.current}>
+      {children}
+    </ERDProjectContext.Provider>
+  );
+}
+
+export const useERDProjectStore = () => {
+  const store = useContext(ERDProjectContext);
+
+  if (!store) {
+    throw new Error(
+      'useERDProjectStore must be used within a ERDProjectProvider',
+    );
+  }
+  
+  return store;
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,1 +1,2 @@
+export * from './ERDProjectProvider';
 export * from './TanStackQueryProvider';


### PR DESCRIPTION
## Overview

- ERDProjectProvider를 전역적으로 설정하여 useERDProjectStore를 기존 방식 대신에 사용할 수 있도록 수정했습니다.
