### PR TITLE
[FLOW-25] chore: install husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+node .husky/commit-msg.js $1

--- a/.husky/commit-msg.js
+++ b/.husky/commit-msg.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+const branchName = execSync('git symbolic-ref --short HEAD').toString().trim();
+
+const commitFilePath = process.argv[2];
+
+const commitMessage = fs.readFileSync(commitFilePath, 'utf-8').trim();
+
+const ticketNumberPrefix = `[${branchName}]`;
+
+if (!commitMessage.startsWith(ticketNumberPrefix)) {
+  const newCommitMessage = `${ticketNumberPrefix} ${commitMessage}`;
+  fs.writeFileSync(commitFilePath, newCommitMessage);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-react-hooks": "^4.6.2",
         "globals": "^15.9.0",
+        "husky": "^9.1.6",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "3.3.3",
@@ -5690,6 +5691,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "jest",
     "lint-fix": "eslint . --fix",
-    "prettier-fix": "prettier --write ."
+    "prettier-fix": "prettier --write .",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@emotion/react": "^11.13.3",
@@ -49,6 +50,7 @@
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "globals": "^15.9.0",
+    "husky": "^9.1.6",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "3.3.3",


### PR DESCRIPTION
## Overview

- husky 설정을 통해 커밋 메시지에 prefix를 브랜치 이름으로 추가하도록 수정했습니다.
- 초기 설정시 아래 코드가 실행 1회 필요합니다.

```shell
npm install
npm run prepare
```
