### PR TITLE
[FLOW-23] feat: add useModal, useModalContext hooks, implement ProfileSetting component with mockup data

### DIFF
--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -1,1 +1,0 @@
-export default function SettingPage() {}

--- a/src/components/home/setting/ProfileInformation.tsx
+++ b/src/components/home/setting/ProfileInformation.tsx
@@ -1,0 +1,14 @@
+import { styles } from './ProfileSetting.styles';
+
+export function ProfileInformation() {
+  return (
+    <styles.profileInformationContainer>
+      <styles.profileInformation>
+        <styles.profileName>John Doe</styles.profileName>
+        <styles.profileDescription>
+          Frontend Developer
+        </styles.profileDescription>
+      </styles.profileInformation>
+    </styles.profileInformationContainer>
+  );
+}

--- a/src/components/home/setting/ProfileSetting.styles.ts
+++ b/src/components/home/setting/ProfileSetting.styles.ts
@@ -1,0 +1,127 @@
+import styled from '@emotion/styled';
+
+export const styles = {
+  container: styled.div`
+    display: flex;
+    min-width: 20rem;
+    max-width: 30rem;
+    min-height: 20rem;
+    max-height: 30rem;
+    padding: 2rem;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1 0 0;
+
+    border-radius: 1rem;
+    border: 1px solid #676772;
+    background: #27272a;
+  `,
+
+  profileInformationContainer: styled.div`
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    align-self: stretch;
+  `,
+
+  profileImageFrame: styled.div`
+    width: 9.375rem;
+    height: 9.375rem;
+
+    border-radius: 10.9375rem;
+    border: 1px solid #000;
+    box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      height: 100%;
+    }
+  `,
+
+  profileInformation: styled.div`
+    display: flex;
+    width: 15.625rem;
+    height: 16rem;
+    padding: 0.625rem;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.625rem;
+  `,
+
+  profileName: styled.p`
+    align-self: stretch;
+    color: #ededed;
+    font-family: Pretendard;
+    font-size: 1.25rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+  `,
+
+  profileDescription: styled.p`
+    flex: 1 0 0;
+    align-self: stretch;
+
+    color: #dedede;
+    font-family: Pretendard;
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+  `,
+
+  buttons: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    align-self: stretch;
+  `,
+
+  confirmButton: styled.button`
+    all: unset;
+    cursor: pointer;
+
+    display: flex;
+    height: 2rem;
+    justify-content: center;
+    align-items: center;
+    flex: 1 0 0;
+
+    border-radius: 0.25rem;
+    background: #444;
+
+    color: #ededed;
+    text-align: center;
+    font-family: Pretendard;
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+  `,
+
+  cancelButton: styled.button`
+    all: unset;
+    cursor: pointer;
+
+    display: flex;
+    height: 2rem;
+    justify-content: center;
+    align-items: center;
+    flex: 1 0 0;
+
+    border-radius: 0.25rem;
+    background: #2f2f2f;
+
+    color: #ededed;
+    text-align: center;
+    font-family: Pretendard;
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+  `,
+};

--- a/src/components/home/setting/ProfileSetting.tsx
+++ b/src/components/home/setting/ProfileSetting.tsx
@@ -1,15 +1,19 @@
 import { ProfileInformation } from './ProfileInformation';
 import { styles } from './ProfileSetting.styles';
 
-interface ProfileSettingProps {
-  onClickCancel: () => void;
-  onClickConfirm: () => void;
-}
+import { useModalContext } from '@/features/modal';
 
-export function ProfileSetting({
-  onClickCancel,
-  onClickConfirm,
-}: ProfileSettingProps) {
+export function ProfileSetting() {
+  const { closeModal } = useModalContext();
+
+  const onClickConfirm = () => {
+    closeModal();
+  };
+
+  const onClickCancel = () => {
+    closeModal();
+  };
+
   return (
     <styles.container>
       <styles.profileInformationContainer>

--- a/src/components/home/setting/ProfileSetting.tsx
+++ b/src/components/home/setting/ProfileSetting.tsx
@@ -1,0 +1,32 @@
+import { ProfileInformation } from './ProfileInformation';
+import { styles } from './ProfileSetting.styles';
+
+interface ProfileSettingProps {
+  onClickCancel: () => void;
+  onClickConfirm: () => void;
+}
+
+export function ProfileSetting({
+  onClickCancel,
+  onClickConfirm,
+}: ProfileSettingProps) {
+  return (
+    <styles.container>
+      <styles.profileInformationContainer>
+        <styles.profileImageFrame>
+          <img
+            src='https://s3-alpha-sig.figma.com/img/8017/7146/ede8cb8e4f94e50ebfdf6c3129c38b3a?Expires=1730073600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=DGXgR7aGoHD5FF5iSMyXM8~oaJxtinh3oWLUab6YA1amP10Qz6nymU3iFy8KJGNNpZHDlCFVAshU8Ks5grKCZ3700ghT1VOrR~ZJpxLDEhN6Qlm-Jj9zugQgjqw8BeH~kC4eltR~JUjSeM2jrdyt5RrK5RgP~RoqqD5qcOmEVelyUK3Kuox5iG6Wp1t7RVgOzHTGbc8yUHOmEi9TAzirfmUQULowUxz3SywwrviygI-0CtI0WW5ZEIwFWKkyFoCgi9U8Gd4WUuBb78iz4ziZ5EWEOfDfGPPsVPhHcuQCGLXafgPvjNFx4DVWhA06ha8ngg4nQHrMQ9X8S-mjwjavAQ__'
+            alt='profile'
+          />
+        </styles.profileImageFrame>
+        <ProfileInformation />
+      </styles.profileInformationContainer>
+      <styles.buttons>
+        <styles.confirmButton onClick={onClickConfirm}>
+          확인
+        </styles.confirmButton>
+        <styles.cancelButton onClick={onClickCancel}>취소</styles.cancelButton>
+      </styles.buttons>
+    </styles.container>
+  );
+}

--- a/src/components/home/setting/index.ts
+++ b/src/components/home/setting/index.ts
@@ -1,0 +1,1 @@
+export * from './ProfileSetting';

--- a/src/components/home/sidebar/Sidebar.styles.ts
+++ b/src/components/home/sidebar/Sidebar.styles.ts
@@ -61,7 +61,7 @@ export const styles = {
     line-height: normal;
   `,
 
-  settingLink: styled(Link)`
+  settingLink: styled.button`
     all: unset;
     cursor: pointer;
 

--- a/src/components/home/sidebar/Sidebar.styles.ts
+++ b/src/components/home/sidebar/Sidebar.styles.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import Link from 'next/link';
 
 export const styles = {
   container: styled.div`

--- a/src/components/home/sidebar/Sidebar.tsx
+++ b/src/components/home/sidebar/Sidebar.tsx
@@ -1,6 +1,11 @@
 import { styles } from './Sidebar.styles';
 
+import { ProfileSetting } from '@/components/home/setting';
+import { useModal } from '@/features/modal';
+
 export function Sidebar() {
+  const { Modal, openModal } = useModal(<ProfileSetting />);
+
   return (
     <styles.container>
       <styles.profileImageFrame>
@@ -12,8 +17,9 @@ export function Sidebar() {
       <styles.userInformation>
         <styles.userName>John Doe</styles.userName>
         <styles.userDescription>Frontend Developer</styles.userDescription>
-        <styles.settingLink href='/setting'>설정</styles.settingLink>
+        <styles.settingLink onClick={openModal}>설정</styles.settingLink>
       </styles.userInformation>
+      {Modal}
     </styles.container>
   );
 }

--- a/src/features/modal/index.ts
+++ b/src/features/modal/index.ts
@@ -1,0 +1,1 @@
+export * from './modal.hook';

--- a/src/features/modal/modal.hook.tsx
+++ b/src/features/modal/modal.hook.tsx
@@ -25,7 +25,22 @@ export const useModal = (children: ReactNode) => {
   const Modal = useMemo(() => {
     if (!isOpen) return null;
     return createPortal(
-      <Background onClick={closeModal}>{children}</Background>,
+      <Background onClick={closeModal}>
+        <div
+          role='button'
+          tabIndex={0}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.stopPropagation();
+            }
+          }}
+        >
+          {children}
+        </div>
+      </Background>,
       document.body,
     );
   }, [isOpen, children]);

--- a/src/features/modal/modal.hook.tsx
+++ b/src/features/modal/modal.hook.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+import { ReactNode, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+const Background = styled.div`
+  display: flex;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100dvw;
+  height: 100dvh;
+  justify-content: center;
+  align-items: center;
+  background: rgba(47, 47, 47, 0.8);
+  backdrop-filter: blur(4px);
+`;
+
+export const useModal = (children: ReactNode) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => setIsOpen(true);
+
+  const closeModal = () => setIsOpen(false);
+
+  const Modal = useMemo(() => {
+    if (!isOpen) return null;
+    return createPortal(
+      <Background onClick={closeModal}>{children}</Background>,
+      document.body,
+    );
+  }, [isOpen, children]);
+
+  return {
+    Modal,
+    openModal,
+    closeModal,
+  };
+};


### PR DESCRIPTION
## Overview

- 프로젝트 전반에 필요한 모달 기능을 훅으로 구현하였습니다.
  - `useModal` 훅을 이용하여 화면 가운데에 원하는 컴포넌트를 가시적으로 보여줄 수 있습니다,
  - `useModalContext` 훅을 이용하여 현재 가운데에 보여지고 있는 모달을 조작할 수 있는 액션을 사용할 수 있습니다.
    - 이를 통해 `useModal` 훅을 이용하여 보여질 컴포넌트 내부에서는 `useModalContext` 훅을 이용하여 현재 모달을 닫는 것과 같은 모달을 조작하기 위한 액션을 사용할 수 있습니다.
- 사용자가 메인 화면에서 설정 버튼을 클릭시 보여질 화면을 목업 데이터를 이용하여 구현하였습니다.
